### PR TITLE
added rm cookie tmp file

### DIFF
--- a/unifi_api
+++ b/unifi_api
@@ -37,6 +37,7 @@ unifi_login() {
 unifi_logout() {
     # logout
     ${curl_cmd} $baseurl/logout
+    rm ${cookie}
 }
 
 unifi_api() {


### PR DESCRIPTION
Hi,

I've added rm ${cookie} in the logout function. Without that the cookie file gets not deleted
and fills /tmp.

Regards,
Alex